### PR TITLE
Prevent NPE when no firstname is returned from LaunchDarkly

### DIFF
--- a/src/main/kotlin/com/procurify/flagcounter/FlagReader.kt
+++ b/src/main/kotlin/com/procurify/flagcounter/FlagReader.kt
@@ -29,7 +29,7 @@ data class FlagDetail(
  * Owner/Maintainer of a flag
  */
 data class Owner(
-        val name: String,
+        val name: String?,
         val email: String
 )
 

--- a/src/main/kotlin/com/procurify/flagcounter/launchdarkly/LaunchDarklyResponses.kt
+++ b/src/main/kotlin/com/procurify/flagcounter/launchdarkly/LaunchDarklyResponses.kt
@@ -25,7 +25,7 @@ data class LDFlagDetail(
  * Feature flag maintainer
  */
 data class LDFlagMaintainer(
-        val firstName: String,
+        val firstName: String?,
         val email: String
 )
 

--- a/src/test/kotlin/com/procurify/flagcounter/launchdarkly/LaunchDarklyFlagReaderTest.kt
+++ b/src/test/kotlin/com/procurify/flagcounter/launchdarkly/LaunchDarklyFlagReaderTest.kt
@@ -53,4 +53,38 @@ class LaunchDarklyFlagReaderTest {
 
         assertEquals(expectedZipped, actualZipped)
     }
+
+    @Test
+    fun `zipping handles maintainers with null first names`() {
+
+        val keyAlpha = "alpha"
+
+        val maintainer = LDFlagMaintainer(null, "")
+
+        val status = LDStatus.LAUNCHED
+
+        val referenceAlpha = LDFlagReference("/path/alpha")
+        val flagResponse = LDFlagResponse(
+                totalCount = 1,
+                items = listOf(
+                        LDFlagDetail(keyAlpha, maintainer, LDFlagLinks(referenceAlpha)),
+                )
+        )
+
+        val flagStatusResponse = LDFlagStatusResponse(
+                listOf(
+                        LDFlagStatus(status, LDStatusLinks(referenceAlpha))
+                )
+        )
+
+        val actualZipped = LaunchDarklyFlagReader.zipFlagsAndStatuses(flagResponse, flagStatusResponse)
+
+        val expectedOwner = Owner(maintainer.firstName, maintainer.email)
+        val expectedStatus = Status.REMOVABLE
+        val expectedZipped = listOf(
+                FlagDetail(keyAlpha, expectedOwner, expectedStatus),
+        )
+
+        assertEquals(expectedZipped, actualZipped)
+    }
 }


### PR DESCRIPTION
Our implementation of Flag Counter was throwing an exception when a first name wasn't returned in the maintainer response from LaunchDarkly